### PR TITLE
Disable back action

### DIFF
--- a/app/src/main/java/is/hi/hbv601/pubquiz/AnswerQuestionActivity.java
+++ b/app/src/main/java/is/hi/hbv601/pubquiz/AnswerQuestionActivity.java
@@ -151,6 +151,7 @@ public class AnswerQuestionActivity extends AppCompatActivity {
             // TODO Check if successful answer
 
             Intent answerQuestionIntent = new Intent(AnswerQuestionActivity.this, AnswerQuestionActivity.class);
+            answerQuestionIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
             startActivity(answerQuestionIntent);
         }
     }

--- a/app/src/main/java/is/hi/hbv601/pubquiz/PubQuiz_Fragment.java
+++ b/app/src/main/java/is/hi/hbv601/pubquiz/PubQuiz_Fragment.java
@@ -137,6 +137,7 @@ public class PubQuiz_Fragment extends Fragment{
             super.onPostExecute( o );
 
             Intent answerQuestionIntent = new Intent(PubQuiz_Fragment.this.getActivity(), AnswerQuestionActivity.class);
+            answerQuestionIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
             startActivity(answerQuestionIntent);
         }
     }


### PR DESCRIPTION
When registering into a new team or after answering a question the team
member should not be able to go back to past questions or into the
registration again. At least not using the back button.